### PR TITLE
Remove extra $original docblock

### DIFF
--- a/src/Stream/HandleInterface.php
+++ b/src/Stream/HandleInterface.php
@@ -49,7 +49,6 @@ interface HandleInterface
     public function open();
 
     /**
-     * @param  string        $origin
      * @param  string        $target
      * @return NodeInterface
      */


### PR DESCRIPTION
This triggers the symfony debug class loader with the following:

```
  1x: The "Vfs\Stream\AbstractHandle::rename()" method will require a new "string $origin" argument in the next major version of its interface "Vfs\Stream\HandleInterface", not defining it is deprecated.
```