### PR TITLE
add Travesersable return type for method getIterator in Directory.php

### DIFF
--- a/src/Node/Directory.php
+++ b/src/Node/Directory.php
@@ -109,7 +109,7 @@ class Directory implements NodeContainerInterface
         $this->dateModified = $dateTime;
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new ArrayIterator($this->nodes);
     }


### PR DESCRIPTION
Directory.php return deprecated notice from getIterator method from PHP version 8.1.